### PR TITLE
fix/#42-correccion-bugs-sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=ServeAt
+sonar.projectName=ServeAt
+sonar.sourceEncoding=UTF-8
+sonar.sources=src/main/java
+sonar.tests=src/test/java
+sonar.coverage.exclusions=src/main/java/com/serveat/core/util/DataInitializer.java


### PR DESCRIPTION
DataInitializer es una clase de uso exclusivo en entorno de desarrollo
(profile dev) cuyo objetivo es inicializar datos de prueba.

No forma parte de la lógica de negocio ni se ejecuta en producción, y no es
adecuada para pruebas unitarias.

Por este motivo se excluye del análisis de cobertura de Sonar para evitar
falsos negativos en las métricas de fiabilidad y cobertura.