### PR TITLE
FIX: traducción correcta al cerrar sesión

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
         </dependency>

--- a/src/main/frontend/generated/flow/generated-flow-imports.js
+++ b/src/main/frontend/generated/flow/generated-flow-imports.js
@@ -1,206 +1,92 @@
 import '@vaadin/polymer-legacy-adapter/style-modules.js';
-import '@vaadin/vertical-layout/theme/lumo/vaadin-vertical-layout.js';
-import '@vaadin/app-layout/theme/lumo/vaadin-app-layout.js';
-import '@vaadin/horizontal-layout/theme/lumo/vaadin-horizontal-layout.js';
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box.js';
+import '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
+import '@vaadin/app-layout/src/vaadin-app-layout.js';
+import '@vaadin/common-frontend/ConnectionIndicator.js';
+import '@vaadin/accordion/src/vaadin-accordion.js';
+import '@vaadin/details/src/vaadin-details.js';
+import '@vaadin/accordion/src/vaadin-accordion-panel.js';
+import '@vaadin/button/src/vaadin-button.js';
+import '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
+import '@vaadin/avatar/src/vaadin-avatar.js';
+import '@vaadin/avatar-group/src/vaadin-avatar-group.js';
+import '@vaadin/card/src/vaadin-card.js';
+import '@vaadin/checkbox/src/vaadin-checkbox.js';
+import '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
+import '@vaadin/combo-box/src/vaadin-combo-box.js';
 import 'Frontend/generated/jar-resources/flow-component-renderer.js';
 import 'Frontend/generated/jar-resources/comboBoxConnector.js';
-import '@vaadin/tooltip/theme/lumo/vaadin-tooltip.js';
-import '@vaadin/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js';
-import '@vaadin/button/theme/lumo/vaadin-button.js';
-import 'Frontend/generated/jar-resources/disableOnClickFunctions.js';
-import '@vaadin/icons/vaadin-iconset.js';
-import '@vaadin/icon/theme/lumo/vaadin-icon.js';
-import '@vaadin/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js';
-import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-sorter.js';
-import '@vaadin/checkbox/theme/lumo/vaadin-checkbox.js';
-import 'Frontend/generated/jar-resources/gridConnector.ts';
-import 'Frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-column-group.js';
-import 'Frontend/generated/jar-resources/lit-renderer.ts';
-import '@vaadin/context-menu/theme/lumo/vaadin-context-menu.js';
+import '@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js';
+import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
+import '@vaadin/context-menu/src/vaadin-context-menu.js';
 import 'Frontend/generated/jar-resources/contextMenuConnector.js';
 import 'Frontend/generated/jar-resources/contextMenuTargetConnector.js';
-import '@vaadin/integer-field/theme/lumo/vaadin-integer-field.js';
-import '@vaadin/notification/theme/lumo/vaadin-notification.js';
-import '@vaadin/dialog/theme/lumo/vaadin-dialog.js';
-import '@vaadin/form-layout/theme/lumo/vaadin-form-layout.js';
-import '@vaadin/form-layout/theme/lumo/vaadin-form-item.js';
-import '@vaadin/date-picker/theme/lumo/vaadin-date-picker.js';
+import '@vaadin/custom-field/src/vaadin-custom-field.js';
+import '@vaadin/date-picker/src/vaadin-date-picker.js';
 import 'Frontend/generated/jar-resources/datepickerConnector.js';
-import '@vaadin/text-area/theme/lumo/vaadin-text-area.js';
-import '@vaadin/email-field/theme/lumo/vaadin-email-field.js';
-import '@vaadin/checkbox-group/theme/lumo/vaadin-checkbox-group.js';
-import '@vaadin/number-field/theme/lumo/vaadin-number-field.js';
-import '@vaadin/password-field/theme/lumo/vaadin-password-field.js';
-import '@vaadin/login/theme/lumo/vaadin-login-form.js';
-import '@vaadin/common-frontend/ConnectionIndicator.js';
+import '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
+import '@vaadin/time-picker/src/vaadin-time-picker.js';
+import 'Frontend/generated/jar-resources/vaadin-time-picker/timepickerConnector.js';
+import '@vaadin/dialog/src/vaadin-dialog.js';
+import 'Frontend/generated/jar-resources/dndConnector.js';
+import '@vaadin/field-highlighter/src/vaadin-field-highlighter.js';
+import '@vaadin/form-layout/src/vaadin-form-layout.js';
+import '@vaadin/form-layout/src/vaadin-form-item.js';
+import '@vaadin/grid/src/vaadin-grid-column-group.js';
+import '@vaadin/grid/src/vaadin-grid.js';
+import '@vaadin/grid/src/vaadin-grid-column.js';
+import '@vaadin/grid/src/vaadin-grid-sorter.js';
+import 'Frontend/generated/jar-resources/gridConnector.ts';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
+import 'Frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
+import '@vaadin/icon/src/vaadin-icon.js';
+import '@vaadin/icons/vaadin-iconset.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/login/src/vaadin-login-form.js';
+import '@vaadin/login/src/vaadin-login-overlay.js';
+import 'Frontend/generated/jar-resources/menubarConnector.js';
+import '@vaadin/menu-bar/src/vaadin-menu-bar.js';
+import '@vaadin/message-input/src/vaadin-message-input.js';
+import 'Frontend/generated/jar-resources/messageListConnector.js';
+import '@vaadin/message-list/src/vaadin-message-list.js';
+import '@vaadin/notification/src/vaadin-notification.js';
+import '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
+import '@vaadin/scroller/src/vaadin-scroller.js';
+import '@vaadin/popover/src/vaadin-popover.js';
+import 'Frontend/generated/jar-resources/vaadin-popover/popover.ts';
+import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+import '@vaadin/radio-group/src/vaadin-radio-button.js';
+import '@vaadin/radio-group/src/vaadin-radio-group.js';
+import 'Frontend/generated/jar-resources/ReactRouterOutletElement.tsx';
+import '@vaadin/select/src/vaadin-select.js';
+import 'Frontend/generated/jar-resources/selectConnector.js';
+import 'Frontend/generated/jar-resources/tooltip.ts';
+import 'Frontend/generated/jar-resources/disableOnClickFunctions.js';
+import '@vaadin/side-nav/src/vaadin-side-nav.js';
+import '@vaadin/side-nav/src/vaadin-side-nav-item.js';
+import '@vaadin/split-layout/src/vaadin-split-layout.js';
+import '@vaadin/tabs/src/vaadin-tab.js';
+import '@vaadin/tabsheet/src/vaadin-tabsheet.js';
+import '@vaadin/tabs/src/vaadin-tabs.js';
+import 'Frontend/generated/jar-resources/vaadin-big-decimal-field.js';
+import '@vaadin/email-field/src/vaadin-email-field.js';
+import '@vaadin/integer-field/src/vaadin-integer-field.js';
+import '@vaadin/number-field/src/vaadin-number-field.js';
+import '@vaadin/password-field/src/vaadin-password-field.js';
+import '@vaadin/text-area/src/vaadin-text-area.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
+import 'Frontend/generated/jar-resources/lit-renderer.ts';
+import '@vaadin/grid/src/vaadin-grid-tree-toggle.js';
+import '@vaadin/upload/src/vaadin-upload.js';
+import '@vaadin/virtual-list/src/vaadin-virtual-list.js';
+import 'Frontend/generated/jar-resources/virtualListConnector.js';
 import '@vaadin/vaadin-lumo-styles/color-global.js';
 import '@vaadin/vaadin-lumo-styles/typography-global.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
-import 'Frontend/generated/jar-resources/ReactRouterOutletElement.tsx';
-
-const loadOnDemand = (key) => {
-  const pending = [];
-  if (key === 'd48306c7f58d868a24acb614298f70683d4b02ad5c3d03ddf28e4b61d7ea6adb') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '2836704b6a4e5a76c4910d23a64cf07df1d060881d2c30209a76c76b08a60cf6') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === 'c7e4033086b72cdba5b0dd0850c78a77e75b5cb09d4603742f4820558cdb6dcb') {
-    pending.push(import('./chunks/chunk-fa7d463110bad945b6b751c5309bdbf3fa1fceabd4958a28151ce43809c97283.js'));
-  }
-  if (key === '54c0f894a9dc7de32d2a7d3719c13e544046c6ff62fe6c5a425c1ffa8e31117b') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '329577fc22500ed27f6bb7c4991bb3d72402d18135b4cf4e27afb8652b898c63') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === '92720abaccb4e60701cc597c12129e910f4d598aacf567930627203320bc4bfe') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'c103ac4acdd97eb1e38c938c36b0f2e595b8231be8fce7fba153c753e39e6f1a') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === '7b3ec6a5884b2290df25b2382f1b9ded6c1196da97116e8bf137241fe62a9c1b') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'd0744cfa354c8ddf3d4d9839d3ff806f21428db9295d23b4349fa0d4327e81ca') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'd30cc2ba72f4a1fd678595d589cf883594c634f1885c38f47a16a38d66a08d3c') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '99cb4de1cc42ea884499f319d927737b345c3d25e3b6c809289911c7752d972f') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'c99872e39569e7b6eda40d11da20f0040d720ac9e825470524c9508cdce1dbf7') {
-    pending.push(import('./chunks/chunk-10d625c1a9acea6a387904900d9743b52ba669f26d2c54ce97be3d44fb09ddb1.js'));
-  }
-  if (key === 'd2e3a2adfd16dd72332b48200157bc6b12146f66d7890640cf05283138b0639a') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === 'd67f8cacee47d7e0b75c76ebfb5b0333bca4bf6c4cac836dad69113749b92c3e') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '09db70a250ff9a86a12e3a1f20c49f6bba0c695b40e02e35436db665e22a8e7f') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === 'f69521cc45f1d29f86cc43d0bb0c92404bf848d7ee6ef5571cca77e4c002dcb3') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === '6cb1b5ed6a2aa69a55aac1736d74c11eb8376a347fe2c39711a0209741814305') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'd42a61c987c206e717a7130fffd85d2dc379a8c95a017cc25aaa76b8d084838e') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '6170886d4426c0bd1a22410a5cc0483f740b8b49c432c1072d6a1074736fc039') {
-    pending.push(import('./chunks/chunk-8ae4ed50da8a1032211f51b8383e662ced72779c2069d557cfcd597fbad30ce0.js'));
-  }
-  if (key === 'bf39abd46404cd8820465c744185cb9609df65858323c9c9fd7460addaa3917f') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === 'a893306eca0899ee551f284b0144d0e2b6a4134982aa18aeed7d1a1b63ba34d4') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '351b691331c8167936ca4079fb964cd3721b7178401e36eb8c15fcf576212650') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === '5cdc53809565dd1541e66a510cf844c37f3f1b39f56afb6e6f200cf79a23532f') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'd705ee6e209f31276ebf261d1c0ddd50c86961ccdc0e79afdae872f8cfe96497') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'e43e1d08de3b19e9c5bbf47ce44820a7118f34fe8cef53f1eddd61c7b692743c') {
-    pending.push(import('./chunks/chunk-17b29cc98ee3ddc52854ee21e81fbc1d2b8d7675de1369a1de891ee37391ab6d.js'));
-  }
-  if (key === '9571e6df636f06fdfb7241f43df8095f5ef958dda06b7e5640d95a438046243b') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '21d1e4231e7a77200fafa933e7c53e76c60dd8c67ad85d34d44dd851b5bdf06a') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'e0718dcf21e3fcd3e04c64ed00052d35e2ad6aaa5bbc4b048303712ebfdbc45f') {
-    pending.push(import('./chunks/chunk-e78c6b4f37ef16f1c4600771435e9c1f9dfce1810876cb843941b8514e707cea.js'));
-  }
-  if (key === 'df4482fe5bce6e9c651eb802e0244dcfc275bfacad776ccb0b3aedb9929f10ba') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === '609e632839b320efe2722730df9eea59ce0a668df8c29a948bc1ad1e9ad32b70') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === 'ddf8512709f36d8a514e0990dfb6206ec8969ec2a8bc9742e32bb312755a69b9') {
-    pending.push(import('./chunks/chunk-55fdeeaf79ef8609138d8303ab5094339c260f9188d71758782fed7e9cae6833.js'));
-  }
-  if (key === 'a60c666a77d19db59dc54409abc54de940223a2427b9443cb91373d75be091f2') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '050018fefa9ceb73b5792b6ac35f20b576d16c498f821a48667b4baee83f0b18') {
-    pending.push(import('./chunks/chunk-7f61b0b8ec93dea8a087e55e1d2c22345da803e6f83e498640f02ced0406547a.js'));
-  }
-  if (key === '1316d7c7c172502d03e7e5447d190a8f50be9420eecc6d548072f5d0ad3ec68e') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '9dbcf2f180678defbe778a47f83dfa8ca7df05ce2cbd7b43b1f1e5652927db68') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === '8edde3f71f8c3926fe56f80e2557b4ac3628b59261b0e1f1d5d8e7ea68919341') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === '27671b221a411991883a5c05be198f3417570d00f1b48ecafcf0bc278702b370') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'c954b16231eedea3beea7b92b3b203def559b44e0b7cb064521846d91f67edd5') {
-    pending.push(import('./chunks/chunk-e7f07668b78535f4d33d9a0c7634adede2cfc03bc4ec82a68b192553928f165d.js'));
-  }
-  if (key === '9d1a5bb459e4dd1671fce29fd94428714957463c154d9dd85f6cb64e9fda7519') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '56f3ba8f1e17c925d1d50c7382bb2eda24f26122fbbea6fd1cc95804e6077d61') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '21d47036f0bcb7c13a98ad60c6d54ef1e122d32221032b2d5bdd4ee8cfdef1e2') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '386e608a9c6042c8abff5f58526a0375492a8cb4c4d65903c3170ede8daf4f89') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === '1fb242aedeacf8081a8f29821ea5930c6bda0c986ebc6d791371aaec72adb0b1') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === '1418014ac070a900e4a9fbd63802aab9f8c79e92a7aabbc12dbdfb22ac79af0a') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'a0e7184a95e728c893e8f79c50c637a5e9aac30ab6f4706812c5b24a405ac059') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === '5b0cbf242cf0f6850a60c3540183be26db7b1ef000c7a2cb95d988238b167ae3') {
-    pending.push(import('./chunks/chunk-b679027ee2ce7b3f043974cf4f8eb4cbfd43e2c6d683d94545cc9b98ea0d3ed2.js'));
-  }
-  if (key === '4e7e5694026348bb1eeb1cdca218abbdb659b8cadcad82ce4eb0f7bab4a31451') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'f018a79642c8dbc400e77ba275dad00c85096c40446a41646b0a538f467d8634') {
-    pending.push(import('./chunks/chunk-e7f07668b78535f4d33d9a0c7634adede2cfc03bc4ec82a68b192553928f165d.js'));
-  }
-  if (key === '8a6c7597dea2331205e856832b2238fecfc2d74ace062adfe91d56516d9219ac') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '5adb254f208fa28cbe2a3a1f8af93423e731f5f5494fc0adc38063df8269f9a3') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  return Promise.all(pending);
-}
-
+const loadOnDemand = (key) => { return Promise.resolve(0); }
 window.Vaadin = window.Vaadin || {};
 window.Vaadin.Flow = window.Vaadin.Flow || {};
 window.Vaadin.Flow.loadOnDemand = loadOnDemand;

--- a/src/main/frontend/generated/flow/generated-flow-webcomponent-imports.js
+++ b/src/main/frontend/generated/flow/generated-flow-webcomponent-imports.js
@@ -1,206 +1,92 @@
 import { injectGlobalWebcomponentCss } from 'Frontend/generated/jar-resources/theme-util.js';
 
 import '@vaadin/polymer-legacy-adapter/style-modules.js';
-import '@vaadin/vertical-layout/theme/lumo/vaadin-vertical-layout.js';
-import '@vaadin/app-layout/theme/lumo/vaadin-app-layout.js';
-import '@vaadin/horizontal-layout/theme/lumo/vaadin-horizontal-layout.js';
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box.js';
+import '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
+import '@vaadin/app-layout/src/vaadin-app-layout.js';
+import '@vaadin/common-frontend/ConnectionIndicator.js';
+import '@vaadin/accordion/src/vaadin-accordion.js';
+import '@vaadin/details/src/vaadin-details.js';
+import '@vaadin/accordion/src/vaadin-accordion-panel.js';
+import '@vaadin/button/src/vaadin-button.js';
+import '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
+import '@vaadin/avatar/src/vaadin-avatar.js';
+import '@vaadin/avatar-group/src/vaadin-avatar-group.js';
+import '@vaadin/card/src/vaadin-card.js';
+import '@vaadin/checkbox/src/vaadin-checkbox.js';
+import '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
+import '@vaadin/combo-box/src/vaadin-combo-box.js';
 import 'Frontend/generated/jar-resources/flow-component-renderer.js';
 import 'Frontend/generated/jar-resources/comboBoxConnector.js';
-import '@vaadin/tooltip/theme/lumo/vaadin-tooltip.js';
-import '@vaadin/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js';
-import '@vaadin/button/theme/lumo/vaadin-button.js';
-import 'Frontend/generated/jar-resources/disableOnClickFunctions.js';
-import '@vaadin/icons/vaadin-iconset.js';
-import '@vaadin/icon/theme/lumo/vaadin-icon.js';
-import '@vaadin/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js';
-import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-sorter.js';
-import '@vaadin/checkbox/theme/lumo/vaadin-checkbox.js';
-import 'Frontend/generated/jar-resources/gridConnector.ts';
-import 'Frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-column-group.js';
-import 'Frontend/generated/jar-resources/lit-renderer.ts';
-import '@vaadin/context-menu/theme/lumo/vaadin-context-menu.js';
+import '@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js';
+import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
+import '@vaadin/context-menu/src/vaadin-context-menu.js';
 import 'Frontend/generated/jar-resources/contextMenuConnector.js';
 import 'Frontend/generated/jar-resources/contextMenuTargetConnector.js';
-import '@vaadin/integer-field/theme/lumo/vaadin-integer-field.js';
-import '@vaadin/notification/theme/lumo/vaadin-notification.js';
-import '@vaadin/dialog/theme/lumo/vaadin-dialog.js';
-import '@vaadin/form-layout/theme/lumo/vaadin-form-layout.js';
-import '@vaadin/form-layout/theme/lumo/vaadin-form-item.js';
-import '@vaadin/date-picker/theme/lumo/vaadin-date-picker.js';
+import '@vaadin/custom-field/src/vaadin-custom-field.js';
+import '@vaadin/date-picker/src/vaadin-date-picker.js';
 import 'Frontend/generated/jar-resources/datepickerConnector.js';
-import '@vaadin/text-area/theme/lumo/vaadin-text-area.js';
-import '@vaadin/email-field/theme/lumo/vaadin-email-field.js';
-import '@vaadin/checkbox-group/theme/lumo/vaadin-checkbox-group.js';
-import '@vaadin/number-field/theme/lumo/vaadin-number-field.js';
-import '@vaadin/password-field/theme/lumo/vaadin-password-field.js';
-import '@vaadin/login/theme/lumo/vaadin-login-form.js';
-import '@vaadin/common-frontend/ConnectionIndicator.js';
+import '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
+import '@vaadin/time-picker/src/vaadin-time-picker.js';
+import 'Frontend/generated/jar-resources/vaadin-time-picker/timepickerConnector.js';
+import '@vaadin/dialog/src/vaadin-dialog.js';
+import 'Frontend/generated/jar-resources/dndConnector.js';
+import '@vaadin/field-highlighter/src/vaadin-field-highlighter.js';
+import '@vaadin/form-layout/src/vaadin-form-layout.js';
+import '@vaadin/form-layout/src/vaadin-form-item.js';
+import '@vaadin/grid/src/vaadin-grid-column-group.js';
+import '@vaadin/grid/src/vaadin-grid.js';
+import '@vaadin/grid/src/vaadin-grid-column.js';
+import '@vaadin/grid/src/vaadin-grid-sorter.js';
+import 'Frontend/generated/jar-resources/gridConnector.ts';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
+import 'Frontend/generated/jar-resources/vaadin-grid-flow-selection-column.js';
+import '@vaadin/icon/src/vaadin-icon.js';
+import '@vaadin/icons/vaadin-iconset.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/login/src/vaadin-login-form.js';
+import '@vaadin/login/src/vaadin-login-overlay.js';
+import 'Frontend/generated/jar-resources/menubarConnector.js';
+import '@vaadin/menu-bar/src/vaadin-menu-bar.js';
+import '@vaadin/message-input/src/vaadin-message-input.js';
+import 'Frontend/generated/jar-resources/messageListConnector.js';
+import '@vaadin/message-list/src/vaadin-message-list.js';
+import '@vaadin/notification/src/vaadin-notification.js';
+import '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
+import '@vaadin/scroller/src/vaadin-scroller.js';
+import '@vaadin/popover/src/vaadin-popover.js';
+import 'Frontend/generated/jar-resources/vaadin-popover/popover.ts';
+import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+import '@vaadin/radio-group/src/vaadin-radio-button.js';
+import '@vaadin/radio-group/src/vaadin-radio-group.js';
+import 'Frontend/generated/jar-resources/ReactRouterOutletElement.tsx';
+import '@vaadin/select/src/vaadin-select.js';
+import 'Frontend/generated/jar-resources/selectConnector.js';
+import 'Frontend/generated/jar-resources/tooltip.ts';
+import 'Frontend/generated/jar-resources/disableOnClickFunctions.js';
+import '@vaadin/side-nav/src/vaadin-side-nav.js';
+import '@vaadin/side-nav/src/vaadin-side-nav-item.js';
+import '@vaadin/split-layout/src/vaadin-split-layout.js';
+import '@vaadin/tabs/src/vaadin-tab.js';
+import '@vaadin/tabsheet/src/vaadin-tabsheet.js';
+import '@vaadin/tabs/src/vaadin-tabs.js';
+import 'Frontend/generated/jar-resources/vaadin-big-decimal-field.js';
+import '@vaadin/email-field/src/vaadin-email-field.js';
+import '@vaadin/integer-field/src/vaadin-integer-field.js';
+import '@vaadin/number-field/src/vaadin-number-field.js';
+import '@vaadin/password-field/src/vaadin-password-field.js';
+import '@vaadin/text-area/src/vaadin-text-area.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
+import 'Frontend/generated/jar-resources/lit-renderer.ts';
+import '@vaadin/grid/src/vaadin-grid-tree-toggle.js';
+import '@vaadin/upload/src/vaadin-upload.js';
+import '@vaadin/virtual-list/src/vaadin-virtual-list.js';
+import 'Frontend/generated/jar-resources/virtualListConnector.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
-import 'Frontend/generated/jar-resources/ReactRouterOutletElement.tsx';
-
-const loadOnDemand = (key) => {
-  const pending = [];
-  if (key === 'd48306c7f58d868a24acb614298f70683d4b02ad5c3d03ddf28e4b61d7ea6adb') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '2836704b6a4e5a76c4910d23a64cf07df1d060881d2c30209a76c76b08a60cf6') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === 'c7e4033086b72cdba5b0dd0850c78a77e75b5cb09d4603742f4820558cdb6dcb') {
-    pending.push(import('./chunks/chunk-fa7d463110bad945b6b751c5309bdbf3fa1fceabd4958a28151ce43809c97283.js'));
-  }
-  if (key === '54c0f894a9dc7de32d2a7d3719c13e544046c6ff62fe6c5a425c1ffa8e31117b') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '329577fc22500ed27f6bb7c4991bb3d72402d18135b4cf4e27afb8652b898c63') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === '92720abaccb4e60701cc597c12129e910f4d598aacf567930627203320bc4bfe') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'c103ac4acdd97eb1e38c938c36b0f2e595b8231be8fce7fba153c753e39e6f1a') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === '7b3ec6a5884b2290df25b2382f1b9ded6c1196da97116e8bf137241fe62a9c1b') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'd0744cfa354c8ddf3d4d9839d3ff806f21428db9295d23b4349fa0d4327e81ca') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'd30cc2ba72f4a1fd678595d589cf883594c634f1885c38f47a16a38d66a08d3c') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '99cb4de1cc42ea884499f319d927737b345c3d25e3b6c809289911c7752d972f') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'c99872e39569e7b6eda40d11da20f0040d720ac9e825470524c9508cdce1dbf7') {
-    pending.push(import('./chunks/chunk-10d625c1a9acea6a387904900d9743b52ba669f26d2c54ce97be3d44fb09ddb1.js'));
-  }
-  if (key === 'd2e3a2adfd16dd72332b48200157bc6b12146f66d7890640cf05283138b0639a') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === 'd67f8cacee47d7e0b75c76ebfb5b0333bca4bf6c4cac836dad69113749b92c3e') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '09db70a250ff9a86a12e3a1f20c49f6bba0c695b40e02e35436db665e22a8e7f') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === 'f69521cc45f1d29f86cc43d0bb0c92404bf848d7ee6ef5571cca77e4c002dcb3') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === '6cb1b5ed6a2aa69a55aac1736d74c11eb8376a347fe2c39711a0209741814305') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'd42a61c987c206e717a7130fffd85d2dc379a8c95a017cc25aaa76b8d084838e') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '6170886d4426c0bd1a22410a5cc0483f740b8b49c432c1072d6a1074736fc039') {
-    pending.push(import('./chunks/chunk-8ae4ed50da8a1032211f51b8383e662ced72779c2069d557cfcd597fbad30ce0.js'));
-  }
-  if (key === 'bf39abd46404cd8820465c744185cb9609df65858323c9c9fd7460addaa3917f') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === 'a893306eca0899ee551f284b0144d0e2b6a4134982aa18aeed7d1a1b63ba34d4') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '351b691331c8167936ca4079fb964cd3721b7178401e36eb8c15fcf576212650') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === '5cdc53809565dd1541e66a510cf844c37f3f1b39f56afb6e6f200cf79a23532f') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'd705ee6e209f31276ebf261d1c0ddd50c86961ccdc0e79afdae872f8cfe96497') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === 'e43e1d08de3b19e9c5bbf47ce44820a7118f34fe8cef53f1eddd61c7b692743c') {
-    pending.push(import('./chunks/chunk-17b29cc98ee3ddc52854ee21e81fbc1d2b8d7675de1369a1de891ee37391ab6d.js'));
-  }
-  if (key === '9571e6df636f06fdfb7241f43df8095f5ef958dda06b7e5640d95a438046243b') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '21d1e4231e7a77200fafa933e7c53e76c60dd8c67ad85d34d44dd851b5bdf06a') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'e0718dcf21e3fcd3e04c64ed00052d35e2ad6aaa5bbc4b048303712ebfdbc45f') {
-    pending.push(import('./chunks/chunk-e78c6b4f37ef16f1c4600771435e9c1f9dfce1810876cb843941b8514e707cea.js'));
-  }
-  if (key === 'df4482fe5bce6e9c651eb802e0244dcfc275bfacad776ccb0b3aedb9929f10ba') {
-    pending.push(import('./chunks/chunk-5c637ea9cc630bcba2509588a8c452ff5dca809e8f5de3145899b7c21c28c32c.js'));
-  }
-  if (key === '609e632839b320efe2722730df9eea59ce0a668df8c29a948bc1ad1e9ad32b70') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === 'ddf8512709f36d8a514e0990dfb6206ec8969ec2a8bc9742e32bb312755a69b9') {
-    pending.push(import('./chunks/chunk-55fdeeaf79ef8609138d8303ab5094339c260f9188d71758782fed7e9cae6833.js'));
-  }
-  if (key === 'a60c666a77d19db59dc54409abc54de940223a2427b9443cb91373d75be091f2') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '050018fefa9ceb73b5792b6ac35f20b576d16c498f821a48667b4baee83f0b18') {
-    pending.push(import('./chunks/chunk-7f61b0b8ec93dea8a087e55e1d2c22345da803e6f83e498640f02ced0406547a.js'));
-  }
-  if (key === '1316d7c7c172502d03e7e5447d190a8f50be9420eecc6d548072f5d0ad3ec68e') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '9dbcf2f180678defbe778a47f83dfa8ca7df05ce2cbd7b43b1f1e5652927db68') {
-    pending.push(import('./chunks/chunk-decff5c0485af59d1308d67d4dd00cc70ec37e2142a6fc4e9184962b9bd8240a.js'));
-  }
-  if (key === '8edde3f71f8c3926fe56f80e2557b4ac3628b59261b0e1f1d5d8e7ea68919341') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === '27671b221a411991883a5c05be198f3417570d00f1b48ecafcf0bc278702b370') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === 'c954b16231eedea3beea7b92b3b203def559b44e0b7cb064521846d91f67edd5') {
-    pending.push(import('./chunks/chunk-e7f07668b78535f4d33d9a0c7634adede2cfc03bc4ec82a68b192553928f165d.js'));
-  }
-  if (key === '9d1a5bb459e4dd1671fce29fd94428714957463c154d9dd85f6cb64e9fda7519') {
-    pending.push(import('./chunks/chunk-1b9d6c1b73478f514140e763ce5099742ab157a26823f0229ba0e46415c0152c.js'));
-  }
-  if (key === '56f3ba8f1e17c925d1d50c7382bb2eda24f26122fbbea6fd1cc95804e6077d61') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '21d47036f0bcb7c13a98ad60c6d54ef1e122d32221032b2d5bdd4ee8cfdef1e2') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '386e608a9c6042c8abff5f58526a0375492a8cb4c4d65903c3170ede8daf4f89') {
-    pending.push(import('./chunks/chunk-de6f45bf71e6683e92ca9865182b5238a814637c8f1041cdb16e9713187be4c8.js'));
-  }
-  if (key === '1fb242aedeacf8081a8f29821ea5930c6bda0c986ebc6d791371aaec72adb0b1') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === '1418014ac070a900e4a9fbd63802aab9f8c79e92a7aabbc12dbdfb22ac79af0a') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'a0e7184a95e728c893e8f79c50c637a5e9aac30ab6f4706812c5b24a405ac059') {
-    pending.push(import('./chunks/chunk-3692fb1910057fd6401c523e67e8fd53aa97cd994f21f6d6c5bfcf748283b80b.js'));
-  }
-  if (key === '5b0cbf242cf0f6850a60c3540183be26db7b1ef000c7a2cb95d988238b167ae3') {
-    pending.push(import('./chunks/chunk-b679027ee2ce7b3f043974cf4f8eb4cbfd43e2c6d683d94545cc9b98ea0d3ed2.js'));
-  }
-  if (key === '4e7e5694026348bb1eeb1cdca218abbdb659b8cadcad82ce4eb0f7bab4a31451') {
-    pending.push(import('./chunks/chunk-433c7e751f3c58ea1c9eb50dd222d8863c79929b502f52cf3ae55a74257d5dcd.js'));
-  }
-  if (key === 'f018a79642c8dbc400e77ba275dad00c85096c40446a41646b0a538f467d8634') {
-    pending.push(import('./chunks/chunk-e7f07668b78535f4d33d9a0c7634adede2cfc03bc4ec82a68b192553928f165d.js'));
-  }
-  if (key === '8a6c7597dea2331205e856832b2238fecfc2d74ace062adfe91d56516d9219ac') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  if (key === '5adb254f208fa28cbe2a3a1f8af93423e731f5f5494fc0adc38063df8269f9a3') {
-    pending.push(import('./chunks/chunk-ae2144bd1f8a3a585a88a826000d6f9063806d0b772fbadd8a70beaf2959850d.js'));
-  }
-  return Promise.all(pending);
-}
-
+const loadOnDemand = (key) => { return Promise.resolve(0); }
 window.Vaadin = window.Vaadin || {};
 window.Vaadin.Flow = window.Vaadin.Flow || {};
 window.Vaadin.Flow.loadOnDemand = loadOnDemand;

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -8,6 +8,14 @@ logout=Logout
 pedido=Order
 confirm=Confirm
 cancel=Cancel
+# ===============================
+# LOGOUT
+# ===============================
+logout.titulo=Sign out
+logout.mensaje=Are you sure you want to sign out?
+logout.confirmar=Sign out
+logout.cancelar=Cancel
+
 
 # ===============================
 # NAV
@@ -80,7 +88,7 @@ registro.usuario=Username
 registro.password=Password
 registro.telefono=Phone
 registro.direccion=Address
-registro.telefono.helper=Numbers only (9?15 digits)
+registro.telefono.helper=Numbers only (9-15 digits)
 registro.email.error=Invalid email
 registro.boton=Sign up
 

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -8,6 +8,14 @@ logout=Cerrar sesión
 pedido=Pedido
 confirm=Confirmar
 cancel=Cancelar
+# ===============================
+# LOGOUT
+# ===============================
+logout.titulo=Cerrar sesión
+logout.mensaje=¿Estás seguro de que deseas cerrar sesión?
+logout.confirmar=Sí, cerrar sesión
+logout.cancelar=Cancelar
+
 
 # ===============================
 # NAV
@@ -80,7 +88,7 @@ registro.usuario=Usuario
 registro.password=Contraseña
 registro.telefono=Teléfono
 registro.direccion=Dirección
-registro.telefono.helper=Solo números (9?15 dígitos)
+registro.telefono.helper=Solo números (9-15 dígitos)
 registro.email.error=Email no válido
 registro.boton=Registrarse
 


### PR DESCRIPTION
Se ha corregido un problema de internacionalización por el cual, al hacer clic en "Salir", el texto del cierre de sesión no se traducía correctamente.
Ahora el mensaje/etiqueta del logout respeta la configuración de i18n de la aplicación.