### PR TITLE
FEAT: reordenar-cabecera-empleados

### DIFF
--- a/src/main/java/com/serveat/view/layout/MainLayout.java
+++ b/src/main/java/com/serveat/view/layout/MainLayout.java
@@ -63,7 +63,6 @@ public class MainLayout extends AppLayout {
         Locale localeActual = VaadinSession.getCurrent().getLocale();
         selectorIdioma.setValue(localeActual != null ? localeActual : new Locale("es", "ES"));
 
-        // 🔁 Cambio de idioma + recarga automática
         selectorIdioma.addValueChangeListener(e -> {
             if (e.getValue() != null) {
                 VaadinSession.getCurrent().setLocale(e.getValue());
@@ -161,11 +160,13 @@ public class MainLayout extends AppLayout {
         HorizontalLayout header = new HorizontalLayout(
                 logo,
                 spacer,
+
+                // 🔹 NUEVO ORDEN
                 selectorIdioma,
-                panelContainer,
                 bloqueUsuario,
                 linkInicio,
                 linkCarta,
+                panelContainer,
                 linkContacto,
                 linkInfo,
                 linkLogin,


### PR DESCRIPTION
Se ha reorganizado el orden de los elementos de la cabecera (panel, contacto, selector de idioma, información de usuario y acción de cierre de sesión) para mejorar la experiencia de usuario y mantener una estructura común